### PR TITLE
Change Crowdvoucher Telegram URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@ a{
 <h2 class="cw">Crowdvoucher</h2>
 <a class="cv" href="https://mateoneira.com/poh_crowdvoucher/">mateoneira.com/poh_crowdvoucher</a>
 <br><br>
-<a class="cv" href="https://vouch.democracy.earth">Crowdvoucher Telegram</a>
+<a class="cv" href="https://t.me/joinchat/OQH0QZHmEr5hZTJh">Crowdvoucher Telegram</a>
 <br><br><br>
 <hr>
 <h2 class="bm">Related Sites</h2>


### PR DESCRIPTION
There is an SSL issue with the short URL for the Crowdvoucher Telegram. Update it to point directly at the Telegram link instead.